### PR TITLE
Change labor ownership behavior

### DIFF
--- a/db/update_to_051.sql
+++ b/db/update_to_051.sql
@@ -57,13 +57,13 @@ VALUES
 	(1,1,NULL,0,1,'Reboot or release the system'),
 	(2,2,1,0,1,'System rebooted'),
 	(3,3,NULL,0,1,'Release or acknowledge downtime'),
-	(4,4,3,0,1,'Perform maintenance'),
+	(4,4,3,1,0,'Perform maintenance'),
 	(5,5,4,1,0,'Maintenance completed'),
-	(6,6,3,0,1,'Acknowledge maintenance'),
+	(6,6,3,1,0,'Perform online maintenance'),
 	(7,5,6,1,0,'Maintenance completed'),
-	(8,7,3,0,1,'Maintenance cancelled'),
-	(9,7,4,0,1,'Maintenance cancelled'),
-	(10,7,6,0,1,'Maintenance cancelled');
+	(8,7,3,1,0,'Maintenance cancelled'),
+	(9,7,4,1,0,'Maintenance cancelled'),
+	(10,7,6,1,0,'Maintenance cancelled');
 
 /*!40000 ALTER TABLE fates ENABLE KEYS */;
 UNLOCK TABLES;

--- a/hermes/webapp/src/templates/fateViewer.html
+++ b/hermes/webapp/src/templates/fateViewer.html
@@ -1,3 +1,3 @@
 <div ng-controller="FateCtrl as fateCtrl">
-    <div id="fatesView" style="width: 100%; height: 600px; border: 1px #000 dotted; overflow: scroll"></div>
+    <div id="fatesView" style="width: 100%; height: 200px;"></div>
 </div>

--- a/tests/api_tests/data/set1/fates.json
+++ b/tests/api_tests/data/set1/fates.json
@@ -15,13 +15,13 @@
   "fate4": {
     "creationEventTypeId": 4,
     "followsId": 3,
+    "forCreator": true,
+    "forOwner": false,
     "description": "A system that needs maintenance made ready before maintenance can occur."
   },
   "fate5": {
     "creationEventTypeId": 5,
     "followsId": 4,
-    "forCreator": true,
-    "forOwner": false,
     "description": "Maintenance must be performed on a system that is prepped."
   }
 }

--- a/tests/api_tests/test_quests.py
+++ b/tests/api_tests/test_quests.py
@@ -241,7 +241,7 @@ def test_quest_lifecycle(sample_data1_server):
 
     target_time = datetime.utcnow() + timedelta(days=7)
 
-    # Create a quest
+    # Create a quest with system-maintenance required
     assert_created(
         client.create(
             "/quests",
@@ -468,8 +468,8 @@ def test_quest_lifecycle(sample_data1_server):
                         "creationEventTypeId": 4,
                         "description": "A system that needs maintenance made ready before maintenance can occur.",
                         "followsId": 3,
-                        "forCreator": False,
-                        "forOwner": True,
+                        "forOwner": False,
+                        "forCreator": True,
                         "id": 4,
                         "precedesIds": [5],
                     },
@@ -496,8 +496,8 @@ def test_quest_lifecycle(sample_data1_server):
                         "creationEventTypeId": 4,
                         "description": "A system that needs maintenance made ready before maintenance can occur.",
                         "followsId": 3,
-                        "forCreator": False,
-                        "forOwner": True,
+                        "forOwner": False,
+                        "forCreator": True,
                         "id": 4,
                         "precedesIds": [5],
                     },
@@ -524,8 +524,8 @@ def test_quest_lifecycle(sample_data1_server):
                         "creationEventTypeId": 4,
                         "description": "A system that needs maintenance made ready before maintenance can occur.",
                         "followsId": 3,
-                        "forCreator": False,
-                        "forOwner": True,
+                        "forOwner": False,
+                        "forCreator": True,
                         "id": 4,
                         "precedesIds": [5],
                     },

--- a/tests/model_tests/test_labors.py
+++ b/tests/model_tests/test_labors.py
@@ -277,9 +277,13 @@ def test_longer_chain(sample_data2):
     labors = sample_data2.query(Labor).all()
     assert len(labors) == 0
 
+    # system-maintenance audit
     event_type_a = sample_data2.query(EventType).get(1)
+    # system-maintenance needed
     event_type_b = sample_data2.query(EventType).get(2)
+    # system-maintenance ready
     event_type_c = sample_data2.query(EventType).get(3)
+    # system-maintenance completed
     event_type_d = sample_data2.query(EventType).get(4)
 
     host = sample_data2.query(Host).get(1)
@@ -307,14 +311,14 @@ def test_longer_chain(sample_data2):
     assert len(labors) == 1
     assert len(host.labors) == 2
     assert labors[0].starting_labor_id == starting_labor_id
-    assert labors[0].for_creator is True
+    assert labors[0].for_creator is False
 
     event_c = Event.create(sample_data2, host, "system", event_type_c)
     labors = Labor.get_open_unacknowledged(sample_data2)
     assert len(labors) == 1
     assert len(host.labors) == 3
     assert labors[0].starting_labor_id == starting_labor_id
-    assert labors[0].for_creator is False
+    assert labors[0].for_creator is True
 
     # This last event closes the final labor but does not create a new labor
     event_d = Event.create(sample_data2, host, "system", event_type_d)

--- a/tests/model_tests/test_quests.py
+++ b/tests/model_tests/test_quests.py
@@ -361,14 +361,10 @@ def test_complex_chaining1(sample_data2):
 
     assert labor1.host == hosts[0]
     assert labor2.host == hosts[1]
-    # True b/c of Fate #2
     assert labor1.for_owner is True
-    # True b/c of Fate #4
-    assert labor1.for_creator is True
-    # True b/c of Fate #2
+    assert labor1.for_creator is False
     assert labor2.for_owner is True
-    # True b/c of Fate #4
-    assert labor2.for_creator is True
+    assert labor2.for_creator is False
     assert labor1.creation_event == event1
     assert labor2.creation_event == event2
 
@@ -539,10 +535,8 @@ def test_complex_chaining3(sample_data2):
     )
     assert bravo_quest.get_open_labors().all()[0].creation_event == event1
     assert bravo_quest.get_open_labors().all()[0].starting_labor_id == hosts[0].events[0].id
-    # True b/c of Fate #2
     assert bravo_quest.get_open_labors().all()[0].for_owner is True
-    # True b/c of Fate #4
-    assert bravo_quest.get_open_labors().all()[0].for_creator is True
+    assert bravo_quest.get_open_labors().all()[0].for_creator is False
     assert len(bravo_quest.labors) == 2
 
     # Now we progress the bravo quest again by throwing sys-maint-ready
@@ -553,8 +547,8 @@ def test_complex_chaining3(sample_data2):
     )
     assert bravo_quest.get_open_labors().all()[0].creation_event == event1b
     assert bravo_quest.get_open_labors().all()[0].starting_labor_id == hosts[0].events[0].id
-    assert bravo_quest.get_open_labors().all()[0].for_owner is True
-    assert bravo_quest.get_open_labors().all()[0].for_creator is False
+    assert bravo_quest.get_open_labors().all()[0].for_owner is False
+    assert bravo_quest.get_open_labors().all()[0].for_creator is True
     assert len(bravo_quest.labors) == 3
 
     # Now we progress the charlie quest with the system-reboot-completed event

--- a/tests/sample_data/sample_data1.sql
+++ b/tests/sample_data/sample_data1.sql
@@ -28,15 +28,15 @@ VALUES
 
 INSERT INTO fates
 VALUES
-	(1,1,NULL, 0, 1, 'Reboot or release the system.');
+	(1,1,NULL, 0, 1, 'Reboot or release the system');
 
 INSERT INTO fates
 VALUES
-	(2,2,1, 0, 1, 'A reboot finishes labors.');
+	(2,2,1, 0, 1, 'System rebooted');
 
 INSERT INTO fates
 VALUES
-	(3,4,1, 0, 1, 'A release finishes labors');
+	(3,4,1, 0, 1, 'System released');
 
 INSERT INTO fates
 VALUES
@@ -44,7 +44,7 @@ VALUES
 
 INSERT INTO fates
 VALUES
-	(5,4,4, 0, 1, 'Perform maintenance');
+	(5,4,4, 1, 0, 'Perform maintenance');
 
 INSERT INTO fates
 VALUES

--- a/tests/sample_data/sample_data2.sql
+++ b/tests/sample_data/sample_data2.sql
@@ -36,15 +36,15 @@ VALUES
 
 INSERT INTO fates
 VALUES
-	(3,3,2, 1, 0, 'Maintenance is needed so machine must be made ready.');
+	(3,3,2, 1, 0, 'Perform maintenance');
 
 INSERT INTO fates
 VALUES
-	(4,4,3, 0, 1, 'System is ready for maintenance might need work done.');
+	(4,4,3, 1, 0, 'Maintenance completed');
 
 INSERT INTO fates
 VALUES
-	(5,6,2, 0, 1, 'Maintenance is needed but a reboot might work.');
+	(5,6,2, 0, 1, 'System rebooted to finish maintenance');
 
 INSERT INTO fates
 VALUES
@@ -52,11 +52,11 @@ VALUES
 
 INSERT INTO fates
 VALUES
-	(7,6, 6, 0, 1, 'Reboot the system.');
+	(7,6, 6, 0, 1, 'Restart puppet');
 
 INSERT INTO fates
 VALUES
-	(8,7,7, 0, 1, 'Reboot was completed so puppet must be restarted.');
+	(8,7,7, 1, 0, 'Puppet restarted');
 
 INSERT INTO hosts
     VALUES (1, 'example.dropbox.com');


### PR DESCRIPTION
In the previous way the world worked, fates were open chains
so when a fate create a labor, we decided if that labor was for
the system owner or the service owner by looking at the fates
that came afterwards.  Now, the fate that creates the labor
must decide for whom the labor exists.
