### PR TITLE
Allow users to throw events from the quests page

### DIFF
--- a/bin/hermes-notify
+++ b/bin/hermes-notify
@@ -125,13 +125,16 @@ def main():
             "on a shell server:"
             "\n\n"
             "$ hermes event create [event] --host [hostname].\n\n"
-            "Or you can visit {}/v1/labors\n\n".format(settings.frontend)
+            "Or you can visit the quests linked below.\n\n".format(settings.frontend)
         )
 
         for quest_id in info[owner]:
             quest = find_quest(open_quests, quest_id)
             if quest:
-                msg += "QUEST {}  [created by {}]:\n".format(
+                msg += (
+                    "==[ QUEST {} ]================================\n"
+                    "Created by {}:\n"
+                ).format(
                     quest_id, quest.creator
                 )
                 if quest.target_time:
@@ -140,7 +143,7 @@ def main():
                     quest.description,
                     width=60, subsequent_indent=""
                 ))
-                msg += "Href: {}/v1/quests/{}\n\n".format(
+                msg += "Details: {}/v1/quests/{}\n\n".format(
                     settings.frontend, quest_id
                 )
             else:

--- a/hermes/webapp/src/css/main.less
+++ b/hermes/webapp/src/css/main.less
@@ -300,6 +300,9 @@ a {
   font-weight: bold;
   margin: 5px 0px;
   padding: 5px;
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
 }
 
 .success-message {
@@ -309,6 +312,9 @@ a {
   font-weight: bold;
   margin: 5px 0px 10px 0px;
   padding: 5px;
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
 }
 
 .success-dialog {
@@ -727,6 +733,11 @@ a {
 }
 
 #confirmModal {
+  border: 5px solid @selected-color;
+  text-align: left;
+}
+
+#confirmModal2 {
   border: 5px solid @selected-color;
   text-align: left;
 }

--- a/hermes/webapp/src/index.html
+++ b/hermes/webapp/src/index.html
@@ -36,7 +36,6 @@
 
         </div>
     </nav>
-
     <div class="container main-container">
         <div ng-view></div>
     </div>

--- a/hermes/webapp/src/js/controllers/questStatusCtrl.js
+++ b/hermes/webapp/src/js/controllers/questStatusCtrl.js
@@ -21,8 +21,10 @@
         vm.labors = null;
         vm.selectedLabors = [];
         vm.countByTypes = null;
-        vm.selectedEventType = null;
-        vm.throwableTypes = null;
+        vm.selectedCreatorType = null;
+        vm.selectedUserType = null;
+        vm.creatorThrowableTypes = null;
+        vm.userThrowableTypes = null;
         vm.createEventsModal = false;
         vm.createInProgress = false;
         vm.limit = 10;
@@ -39,7 +41,8 @@
         vm.filterOwnChanged = filterOwnChanged;
         vm.selectAll = selectAll;
         vm.deselectAll = deselectAll;
-        vm.throwableEventTypesSelection = throwableEventTypesSelection;
+        vm.creatorThrowableTypesSelection = creatorThrowableTypesSelection;
+        vm.userThrowableTypesSelection = userThrowableTypesSelection;
         vm.createEvents = createEvents;
 
         vm.selectOptions = {
@@ -78,8 +81,13 @@
         });
 
         hermesService.getCreatorThrowableEventsTypes().then(function(types) {
-            vm.throwableTypes = types;
-            vm.throwableEventTypesSelection(vm.throwableTypes[0])
+            vm.creatorThrowableTypes = types;
+            vm.creatorThrowableTypesSelection(vm.creatorThrowableTypes[0])
+        });
+
+        hermesService.getUserThrowableEventTypes().then(function(types) {
+            vm.userThrowableTypes = types;
+            vm.userThrowableTypesSelection(vm.userThrowableTypes);
         });
 
 
@@ -473,18 +481,29 @@
         /**
          * The getter/setter for event types
          */
-        function throwableEventTypesSelection(selection) {
+        function creatorThrowableTypesSelection(selection) {
             if (angular.isDefined(selection)) {
-                vm.selectedEventType = selection;
+                vm.selectedCreatorType = selection;
             } else {
-                return vm.selectedEventType;
+                return vm.selectedCreatorType;
+            }
+        }
+
+        /**
+         * The getter/setter for event types
+         */
+        function userThrowableTypesSelection(selection) {
+            if (angular.isDefined(selection)) {
+                vm.selectedUserType = selection;
+            } else {
+                return vm.selectedUserType;
             }
         }
 
         /**
          * Create events for the selected hosts
          */
-        function createEvents() {
+        function createEvents(type) {
             if (vm.createInProgress) return;
             vm.createEventsModal = false;
             vm.createInProgress = true;
@@ -495,8 +514,15 @@
                 return;
             }
 
+            var typeToThrow;
+            if (type == "creator") {
+                typeToThrow = vm.selectedCreatorType;
+            } else {
+                typeToThrow = vm.selectedUserType;
+            }
+
             vm.result = hermesService.createEvents(
-                vm.user, vm.selectedLabors, vm.selectedEventType,
+                vm.user, vm.selectedLabors, typeToThrow,
                 "Created by " + vm.user + " via Web UI."
             )
                 .then(function(response) {

--- a/hermes/webapp/src/js/controllers/questStatusCtrl.js
+++ b/hermes/webapp/src/js/controllers/questStatusCtrl.js
@@ -20,7 +20,7 @@
         vm.selectedQuestCompletedLabors = 0;
         vm.labors = null;
         vm.selectedLabors = [];
-        vm.types = null;
+        vm.countByTypes = null;
         vm.selectedEventType = null;
         vm.throwableTypes = null;
         vm.createEventsModal = false;
@@ -276,7 +276,7 @@
             vm.hostOwners = null;
             vm.labors = null;
             vm.selectedLabors = [];
-            vm.types = null;
+            vm.countByTypes = null;
 
             // make an array of all the hostnames, and have the hermes service
             // give us back a hostname to owner mapping
@@ -338,7 +338,7 @@
 
             // sort the unique labors into a buckets based on the owner and labor type
             var sortedLabors = {};
-            vm.types = {};
+            vm.countByTypes = {};
             for (var idx in laborsUnique) {
                 var hostname = laborsUnique[idx]['host']['hostname'];
                 var owner = ownerData[hostname];
@@ -358,7 +358,7 @@
                 if (laborsUnique[idx]['completionEvent']) {
                     var key = laborsUnique[idx]['completionEvent']['eventType']['description'];
                     // update the count of labors by type
-                    vm.types[key] ? vm.types[key]++ : vm.types[key] = 1;
+                    vm.countByTypes[key] ? vm.countByTypes[key]++ : vm.countByTypes[key] = 1;
 
                     // sort into the bucket for this owner, if the labor is for the server owner
                     if (forOwner) {
@@ -396,7 +396,7 @@
                     var key = laborsUnique[idx]['fate']['description'];
 
                     // update the count of labors by type
-                    vm.types[key] ? vm.types[key]++ : vm.types[key] = 1;
+                    vm.countByTypes[key] ? vm.countByTypes[key]++ : vm.countByTypes[key] = 1;
 
                     // sort into the bucket for the server owner if the labor is for the owner
                     if (forOwner) {

--- a/hermes/webapp/src/templates/questStatus.html
+++ b/hermes/webapp/src/templates/questStatus.html
@@ -225,7 +225,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="quest-actions">
+                        <div ng-if="qc.selectedQuest['creator'] == qc.user" class="quest-actions">
                             <button style="float:left"
                                     ng-click="qc.selectAll()">
                                 Select All
@@ -234,15 +234,40 @@
                                     ng-click="qc.deselectAll()">
                                 Deselect All
                             </button>
-                    <span>
-                    Throw <select ng-disabled="qc.selectedLabors.length == 0"
-                                  ng-model="qc.throwableEventTypesSelection"
-                                  ng-model-options="qc.selectOptions"
-                                  ng-options="optValue.description for optValue in qc.throwableTypes">
-                    </select> for {{qc.selectedLabors.length}} selected hosts.
-                    </span>
+                            <span>
+                            Throw <select ng-disabled="qc.selectedLabors.length == 0"
+                                          ng-model="qc.creatorThrowableTypesSelection"
+                                          ng-model-options="qc.selectOptions"
+                                          ng-options="optValue.description for optValue in qc.creatorThrowableTypes">
+                            </select> for {{qc.selectedLabors.length}} selected hosts.
+                            </span>
                             <button class="create-button be-positive"
-                                    ng-click="qc.createEventsModal = true"
+                                    ng-click="qc.createEventsModal = 'creator'"
+                                    ng-disabled="qc.selectedLabors.length == 0">
+                                <img ng-if="qc.createInProgress"
+                                     src="/img/loading_15.gif"
+                                     style="margin: 5px; float: left"/>
+                                Throw Events
+                            </button>
+                        </div>
+                        <div ng-if="qc.selectedQuest['creator'] != qc.user" class="quest-actions">
+                            <button style="float:left"
+                                    ng-click="qc.selectAll()">
+                                Select All
+                            </button>
+                            <button style="float:left"
+                                    ng-click="qc.deselectAll()">
+                                Deselect All
+                            </button>
+                            <span>
+                            Throw <select ng-disabled="qc.selectedLabors.length == 0"
+                                          ng-model="qc.userThrowableTypesSelection"
+                                          ng-model-options="qc.selectOptions"
+                                          ng-options="optValue.description for optValue in qc.userThrowableTypes">
+                            </select> for {{qc.selectedLabors.length}} selected hosts.
+                            </span>
+                            <button class="create-button be-positive"
+                                    ng-click="qc.createEventsModal = 'user'"
                                     ng-disabled="qc.selectedLabors.length == 0">
                                 <img ng-if="qc.createInProgress"
                                      src="/img/loading_15.gif"
@@ -255,19 +280,39 @@
             </div>
         </div>
     </div>
-    <div ng-cloak class="modal-wrapper fade" ng-if="qc.createEventsModal">
+    <div ng-cloak class="modal-wrapper fade" ng-if="qc.createEventsModal == 'creator'">
         <div id="confirmModal" class="modal-dialog" role="dialog">
             <div class="dialog-callout">
-                "{{qc.selectedEventType.description}}"
+                "{{qc.selectedCreatorType.description}}"
             </div>
             <div class="dialog-text">
-                Are you sure you want to create a <code>{{qc.selectedEventType.category}}
-                {{qc.selectedEventType.state}}</code> event for
+                Are you sure you want to create a <code>{{qc.selectedCreatorType.category}}
+                {{qc.selectedCreatorType.state}}</code> event for
                 {{qc.selectedLabors.length}} servers?
             </div>
             <div class="dialog-buttons">
                 <button style="float: none" class="big-button be-positive"
-                        ng-click="qc.createEvents()">Yes
+                        ng-click="qc.createEvents('creator')">Yes
+                </button>
+                <button style="float: none" class="big-button"
+                        ng-click="qc.createEventsModal = false">No
+                </button>
+            </div>
+        </div>
+    </div>
+    <div ng-cloak class="modal-wrapper fade" ng-if="qc.createEventsModal == 'user'">
+        <div id="confirmModal2" class="modal-dialog" role="dialog">
+            <div class="dialog-callout">
+                "{{qc.selectedUserType.description}}"
+            </div>
+            <div class="dialog-text">
+                Are you sure you want to create a <code>{{qc.selectedUserType.category}}
+                {{qc.selectedUserType.state}}</code> event for
+                {{qc.selectedLabors.length}} servers?
+            </div>
+            <div class="dialog-buttons">
+                <button style="float: none" class="big-button be-positive"
+                        ng-click="qc.createEvents('user')">Yes
                 </button>
                 <button style="float: none" class="big-button"
                         ng-click="qc.createEventsModal = false">No

--- a/hermes/webapp/src/templates/questStatus.html
+++ b/hermes/webapp/src/templates/questStatus.html
@@ -159,7 +159,7 @@
                     <div ng-if="qc.labors" class="quest-details">
                         <div quest-progress-chart
                              colors="qc.colors"
-                             types="qc.types"
+                             types="qc.countByTypes"
                              data="qc.selectedQuestDetails">
                         </div>
                         <div class="quest-overview">

--- a/hermes/webapp/src/templates/userHome.html
+++ b/hermes/webapp/src/templates/userHome.html
@@ -4,6 +4,6 @@
     </div>
     <div class="row">
         <div class="col-md-3 col-md-offset-3 quest-info"><button ng-if="ctrl.totalQuests != null" ng-click="ctrl.goToQuestsPage()">{{ctrl.totalQuests}} total open quests.<br/>{{ctrl.totalUserCreatedQuests}} created by you.</button></div>
-        <div class="col-md-3 labor-info"><button ng-if="ctrl.totalUserLabors != null" ng-click="ctrl.goToLaborsPage()">{{ctrl.totalLabors}} total open labors.<br/>{{ctrl.totalUserLabors}} are for you.</button></div>
+        <div class="col-md-3 labor-info"><button ng-if="ctrl.totalUserLabors != null" ng-click="ctrl.goToLaborsPage()">{{ctrl.totalLabors}} total open labors.<br/>{{ctrl.totalUserLabors}} {{ctrl.totalUserLabors == 1 ? "is" : "are"}} for you.</button></div>
     </div>
 </div>


### PR DESCRIPTION
When pulling up quest details, if user is the owner, give him those events as options to throw.  Otherwise, let the user throw the same events they could throw from the labors page.
