### PR TITLE
On afterEvent search, use ID's in the query

### DIFF
--- a/hermes/handlers/api.py
+++ b/hermes/handlers/api.py
@@ -1272,7 +1272,7 @@ class EventsHandler(ApiHandler):
             if not event:
                 raise exc.BadRequest("No event of type {} found".format(after_event_type))
             else:
-                events = events.filter(Event.timestamp >= event.timestamp)
+                events = events.from_self().filter(Event.id >= event.id)
 
         offset, limit, expand = self.get_pagination_values()
         events, total = self.paginate_query(events, offset, limit)

--- a/hermes/webapp/src/js/controllers/questStatusCtrl.js
+++ b/hermes/webapp/src/js/controllers/questStatusCtrl.js
@@ -343,6 +343,7 @@
          */
         function newQuestSelection(quest) {
             vm.errorMessage = null;
+            vm.createSuccessMessage = null;
             vm.selectedQuest = quest;
             vm.selectedQuestDetails = null;
             vm.selectedQuestUniqueLabors = 0;


### PR DESCRIPTION
When identifying the event based on event-type, use that event's ID instead of timestamp to find all other
subsequent alerts
