### PR TITLE
Add the ability to turn off returning a totalEvents count from the ev…

### DIFF
--- a/bin/hermes-server
+++ b/bin/hermes-server
@@ -78,7 +78,8 @@ def main():
         "db_uri": settings.database,
         "db_engine": None,
         "db_session": None,
-        "domain": settings.domain
+        "domain": settings.domain,
+        "count_events": settings.count_events,
     }
 
     application = Application(my_settings=my_settings, **tornado_settings)

--- a/hermes/handlers/api.py
+++ b/hermes/handlers/api.py
@@ -1280,19 +1280,20 @@ class EventsHandler(ApiHandler):
             events = events.filter(Event.id >= int(after_event_id))
 
         offset, limit, expand = self.get_pagination_values()
-        events, total = self.paginate_query(events, offset, limit)
+        events, total = self.paginate_query(events, offset, limit, count=self.count_events)
 
         events = events.from_self().order_by(Event.timestamp)
 
         json = {
             "limit": limit,
             "offset": offset,
-            "totalEvents": total,
             "events": [
                 event.to_dict(base_uri=self.href_prefix, expand=set(expand))
                 for event in events.all()
             ],
         }
+        if total is not None:
+            json["totalEvents"] = total
 
         self.success(json)
 

--- a/hermes/handlers/util.py
+++ b/hermes/handlers/util.py
@@ -42,6 +42,7 @@ class BaseHandler(RequestHandler):
         self.engine = my_settings.get("db_engine")
         self.session = my_settings.get("db_session")()
         self.domain = my_settings.get("domain")
+        self.count_events = my_settings.get("count_events", True)
 
     def on_finish(self):
         self.session.close()
@@ -126,8 +127,10 @@ class ApiHandler(BaseHandler):
 
         return offset, limit, self.get_arguments("expand")
 
-    def paginate_query(self, query, offset, limit):
-        total = query.count()
+    def paginate_query(self, query, offset, limit, count=True):
+        total = None
+        if count:
+            total = query.count()
 
         query = query.offset(offset)
         if limit is not None:

--- a/hermes/models.py
+++ b/hermes/models.py
@@ -148,7 +148,7 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 def get_db_engine(url, echo=False):
-    engine = create_engine(url, pool_recycle=300, echo=echo)
+    engine = create_engine(url, pool_recycle=300, echo=False)
     Model.metadata.create_all(engine)
 
     if engine.driver == "pysqlite":

--- a/hermes/models.py
+++ b/hermes/models.py
@@ -148,7 +148,7 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 def get_db_engine(url, echo=False):
-    engine = create_engine(url, pool_recycle=300, echo=False)
+    engine = create_engine(url, pool_recycle=300, echo=echo)
     Model.metadata.create_all(engine)
 
     if engine.driver == "pysqlite":

--- a/hermes/settings.py
+++ b/hermes/settings.py
@@ -68,4 +68,5 @@ settings = Settings({
     "dev_email_recipient": "",
     "fullstory_id": None,
     "strongpoc_server": None,
+    "count_events": True,
 })

--- a/tests/api_tests/fixtures.py
+++ b/tests/api_tests/fixtures.py
@@ -29,6 +29,7 @@ class Server(object):
     """ Wrapper around Tornado server with test helpers. """
 
     def __init__(self, tornado_app):
+        self.tornado_app = tornado_app
         self.server = tornado.httpserver.HTTPServer(
             tornado_app
         )

--- a/tests/api_tests/test_events.py
+++ b/tests/api_tests/test_events.py
@@ -356,3 +356,15 @@ def test_after_event_id_query(sample_data2_server):
         },
         strip=["timestamp", "events"]
     )
+
+def test_count_events_disabled(sample_data2_server):
+    client = sample_data2_server
+    client.tornado_server.tornado_app.my_settings["count_events"] = False
+    assert_success(
+        client.get("/events"),
+        {
+            "limit": 10,
+            "offset": 0,
+        },
+        strip=["timestamp", "events"]
+    )


### PR DESCRIPTION
This is a performance optimization for users using MySQL that have a lot of events.  The count queries generated by SQLAlchemy are highly inefficient on MySQL 5.X as they are performing a count on a full subquery or even a nested subquery.  With the number of events on the order of ~3 million, just performing the count takes ~15 seconds, while the actual selection of events (using an index with a reasonable limit) is milliseconds.  

The following inefficient SQL Query was observed being generated by .count() when using the event API (worse case is a nested subquery): 

`SELECT count(*) AS 
    count_1
FROM (
    SELECT 
        anon_2.events_id AS anon_2_events_id, anon_2.events_host_id AS anon_2_events_host_id, anon_2.events_timestamp AS anon_2_events_timestamp, anon_2.events_user AS anon_2_events_user, anon_2.events_event_type_id AS anon_2_events_event_type_id, anon_2.events_note AS anon_2_events_note, anon_2.events_tx AS anon_2_events_tx
        FROM (
            SELECT 
                events.id AS events_id, events.host_id AS events_host_id, events.timestamp AS events_timestamp, events.user AS events_user, events.event_type_id AS events_event_type_id, events.note AS events_note, events.tx AS events_tx
            FROM events ORDER BY events.timestamp DESC
        ) 
        AS anon_2 ORDER BY anon_2.events_timestamp
) AS anon_1`  

This is expected behavior from SQLAlchemy and it is discussed here: http://docs.sqlalchemy.org/en/latest/orm/tutorial.html#counting

Unfortunately, since the events API endpoint is highly complex with lot's of filtering options it will take some thought to generate efficient counts as is explained in the SQLAlchemy docs.  

This pull request addresses an immediate need to be able to turn off return of a count for the events API as it is expected that some users will have lots and lots of events.
